### PR TITLE
Changes test data

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,9 +62,13 @@ This is a file needed by exomiser to run. It contains information on where to fi
 
 This is a file needed by exomiser to run. It contains placeholders in the text that get filled in by the second process of the pipeline just before running exomiser. The one used for testing can be found [here](https://lifebit-featured-datasets.s3.eu-west-1.amazonaws.com/pipelines/exomiser-nf/auto_config.yml)
 
-### --exomiser_data
+### --exomiser_profile
 
-This path refers to the reference data bundle needed by exomiser (~120 GB!). A copy of such files can be found [here](https://lifebit-featured-datasets.s3.eu-west-1.amazonaws.com/pipelines/exomiser-data-bundle/) . The reference dataset has been added as a parameter, allowing flexibility to pull the data from any resource (i.e. cloud, local storage, ftp, ...) and Nextflow will automatically take care of fetching the data without having to add anything to the pipeline itself.
+This is a parameter that defines the kind of reference data. It accepts "test" or "full".
+
+The "full" profile points to the reference data bundle needed by exomiser (~120 GB!). A copy of such files can be found [here](https://lifebit-featured-datasets.s3.eu-west-1.amazonaws.com/pipelines/exomiser-data-bundle/) . The reference dataset has been added as a parameter, allowing flexibility to pull the data from any resource (i.e. cloud, local storage, ftp, ...) and Nextflow will automatically take care of fetching the data without having to add anything to the pipeline itself.
+
+The "test" profile points to some mock data used in testing.
 
 There are other parameters that can be tweaked to personalize the behaviour of the pipeline. These are referenced in `nextflow.config`
 

--- a/conf/data/data.config
+++ b/conf/data/data.config
@@ -2,13 +2,13 @@
 params {
     exomiser_profile{
         'test'{
-            exomiser_data = "${params.reference_data_bucket}/pipelines/exomiser/very_fake/hg38"
+            data_bundle = "${params.reference_data_bucket}/pipelines/exomiser/very_fake/hg38"
             exomiser_phenotype_data = "${params.reference_data_bucket}/pipelines/exomiser/very_fake/2102_phenotype"
             cadd_snvs = "${params.reference_data_bucket}/pipelines/exomiser/very_fake/cadd_snvs"
             phenix_data = "${params.reference_data_bucket}/pipelines/exomiser/very_fake/phenix"
         }
         'full'{
-            exomiser_data   = "${params.reference_data_bucket}/pipelines/exomiser-data-bundle"
+            data_bundle   = "${params.reference_data_bucket}/pipelines/exomiser-data-bundle"
         }
     }
    

--- a/conf/data/data.config
+++ b/conf/data/data.config
@@ -1,6 +1,17 @@
 // If there is any data that needs to be included in the config, it should be placed here using "${params.reference_data_bucket}/path/to/data"
 params {
-    exomiser_data   = "${params.reference_data_bucket}/pipelines/exomiser-data-bundle"
+    exomiser_profile{
+        'test'{
+            exomiser_data = "${params.reference_data_bucket}/pipelines/exomiser/very_fake/hg38"
+            exomiser_phenotype_data = "${params.reference_data_bucket}/pipelines/exomiser/very_fake/2102_phenotype"
+            cadd_snvs = "${params.reference_data_bucket}/pipelines/exomiser/very_fake/cadd_snvs"
+            phenix_data = "${params.reference_data_bucket}/pipelines/exomiser/very_fake/phenix"
+        }
+        'full'{
+            exomiser_data   = "${params.reference_data_bucket}/pipelines/exomiser-data-bundle"
+        }
+    }
+   
     application_properties = "${params.reference_data_bucket}/pipelines/exomiser-nf/application.properties"
     auto_config_yml = '${params.reference_data_bucket}/pipelines/exomiser-nf/auto_config_v2.yml'
 

--- a/conf/data/data.config
+++ b/conf/data/data.config
@@ -1,6 +1,6 @@
 // If there is any data that needs to be included in the config, it should be placed here using "${params.reference_data_bucket}/path/to/data"
 params {
-    exomiser_profile{
+    exomiser_data_profile{
         'test'{
             data_bundle = "${params.reference_data_bucket}/pipelines/exomiser/very_fake/hg38"
             exomiser_phenotype_data = "${params.reference_data_bucket}/pipelines/exomiser/very_fake/2102_phenotype"

--- a/conf/data/data.config
+++ b/conf/data/data.config
@@ -13,6 +13,6 @@ params {
     }
    
     application_properties = "${params.reference_data_bucket}/pipelines/exomiser-nf/application.properties"
-    auto_config_yml = "${params.reference_data_bucket}/pipelines/exomiser-nf/auto_config_v2.yml"
+    auto_config_yml = "${params.reference_data_bucket}/pipelines/exomiser-nf/auto_config_V2.yml"
 
 }

--- a/conf/data/data.config
+++ b/conf/data/data.config
@@ -13,6 +13,6 @@ params {
     }
    
     application_properties = "${params.reference_data_bucket}/pipelines/exomiser-nf/application.properties"
-    auto_config_yml = '${params.reference_data_bucket}/pipelines/exomiser-nf/auto_config_v2.yml'
+    auto_config_yml = "${params.reference_data_bucket}/pipelines/exomiser-nf/auto_config_v2.yml"
 
 }

--- a/conf/family_test.config
+++ b/conf/family_test.config
@@ -1,7 +1,0 @@
-params {
-    families_file     = 's3://lifebit-featured-datasets/pipelines/exomiser-nf/fam_file.tsv'
-    prioritisers    = 'hiPhivePrioritiser'
-    exomiser_data   = "s3://lifebit-featured-datasets/pipelines/exomiser-data-bundle"
-    application_properties = 's3://lifebit-featured-datasets/pipelines/exomiser-nf/application.properties'
-    auto_config_yml = 's3://lifebit-featured-datasets/pipelines/exomiser-nf/auto_config.yml'
-}

--- a/conf/multi_hpo_test.config
+++ b/conf/multi_hpo_test.config
@@ -1,7 +1,0 @@
-params {
-    families_file     = 's3://lifebit-featured-datasets/pipelines/exomiser-nf/fam_file_multi_hpo.tsv'
-    prioritisers    = 'hiPhivePrioritiser'
-    exomiser_data   = "s3://lifebit-featured-datasets/pipelines/exomiser-data-bundle"
-    application_properties = 's3://lifebit-featured-datasets/pipelines/exomiser-nf/application.properties'
-    auto_config_yml = 's3://lifebit-featured-datasets/pipelines/exomiser-nf/auto_config.yml'
-}

--- a/conf/single_vcf_test.config
+++ b/conf/single_vcf_test.config
@@ -1,8 +1,0 @@
-params {
-    families_file     = 's3://lifebit-featured-datasets/pipelines/exomiser-nf/single_vcf.tsv'
-    hpo_terms_file  = 's3://lifebit-featured-datasets/pipelines/exomiser-nf/hpo_terms_file.txt'
-    prioritisers    = 'hiPhivePrioritiser'
-    exomiser_data   = "s3://lifebit-featured-datasets/pipelines/exomiser-data-bundle"
-    application_properties = 's3://lifebit-featured-datasets/pipelines/exomiser-nf/application.properties'
-    auto_config_yml = 's3://lifebit-featured-datasets/pipelines/exomiser-nf/auto_config.yml'
-}

--- a/conf/tests/ci/ci_test_data.config
+++ b/conf/tests/ci/ci_test_data.config
@@ -1,3 +1,3 @@
 params {
-    exomiser_profile = 'test'
+    exomiser_profile_files = 'test'
 }

--- a/conf/tests/ci/ci_test_data.config
+++ b/conf/tests/ci/ci_test_data.config
@@ -1,6 +1,3 @@
 params {
-    exomiser_data = "${params.reference_data_bucket}/pipelines/exomiser/very_fake/hg38"
-    exomiser_phenotype_data = "${params.reference_data_bucket}/pipelines/exomiser/very_fake/2102_phenotype"
-    cadd_snvs = "${params.reference_data_bucket}/pipelines/exomiser/very_fake/cadd_snvs"
-    phenix_data = "${params.reference_data_bucket}/pipelines/exomiser/very_fake/phenix"
+    exomiser_profile = 'test'
 }

--- a/conf/tests/full/test_full.config
+++ b/conf/tests/full/test_full.config
@@ -4,6 +4,6 @@ params {
     sample_name     = 'HG001_NA12878'
     hpo_terms_file  = "${params.reference_data_bucket}/pipelines/exomiser-nf/hpo_terms_file.txt"
     prioritisers    = 'hiPhivePrioritiser'
-    exomiser_profile = 'full'
+    exomiser_profile_files = 'full'
     application_properties = "${params.reference_data_bucket}/pipelines/exomiser-nf/application.properties"
 }

--- a/conf/tests/full/test_full.config
+++ b/conf/tests/full/test_full.config
@@ -4,6 +4,6 @@ params {
     sample_name     = 'HG001_NA12878'
     hpo_terms_file  = "${params.reference_data_bucket}/pipelines/exomiser-nf/hpo_terms_file.txt"
     prioritisers    = 'hiPhivePrioritiser'
-    exomiser_data   = "${params.reference_data_bucket}/pipelines/exomiser-data-bundle"
+    exomiser_profile = 'full'
     application_properties = "${params.reference_data_bucket}/pipelines/exomiser-nf/application.properties"
 }

--- a/conf/tests/full/test_full_family.config
+++ b/conf/tests/full/test_full_family.config
@@ -1,7 +1,7 @@
 params {
     families_file     = 's3://lifebit-featured-datasets/pipelines/exomiser-nf/fam_file.tsv'
     prioritisers    = 'hiPhivePrioritiser'
-    exomiser_data   = "s3://lifebit-featured-datasets/pipelines/exomiser-data-bundle"
+    exomiser_profile = 'full'
     application_properties = 's3://lifebit-featured-datasets/pipelines/exomiser-nf/application.properties'
     auto_config_yml = 's3://lifebit-featured-datasets/pipelines/exomiser-nf/auto_config.yml'
 }

--- a/conf/tests/full/test_full_family.config
+++ b/conf/tests/full/test_full_family.config
@@ -1,7 +1,7 @@
 params {
     families_file     = 's3://lifebit-featured-datasets/pipelines/exomiser-nf/fam_file.tsv'
     prioritisers    = 'hiPhivePrioritiser'
-    exomiser_profile = 'full'
+    exomiser_profile_files = 'full'
     application_properties = 's3://lifebit-featured-datasets/pipelines/exomiser-nf/application.properties'
     auto_config_yml = 's3://lifebit-featured-datasets/pipelines/exomiser-nf/auto_config.yml'
 }

--- a/conf/tests/full/test_full_multi_hpo.config
+++ b/conf/tests/full/test_full_multi_hpo.config
@@ -1,7 +1,7 @@
 params {
     families_file     = 's3://lifebit-featured-datasets/pipelines/exomiser-nf/fam_file_multi_hpo.tsv'
     prioritisers    = 'hiPhivePrioritiser'
-    exomiser_profile = 'full'
+    exomiser_profile_files = 'full'
     application_properties = 's3://lifebit-featured-datasets/pipelines/exomiser-nf/application.properties'
     auto_config_yml = 's3://lifebit-featured-datasets/pipelines/exomiser-nf/auto_config.yml'
 }

--- a/conf/tests/full/test_full_multi_hpo.config
+++ b/conf/tests/full/test_full_multi_hpo.config
@@ -1,7 +1,7 @@
 params {
     families_file     = 's3://lifebit-featured-datasets/pipelines/exomiser-nf/fam_file_multi_hpo.tsv'
     prioritisers    = 'hiPhivePrioritiser'
-    exomiser_data   = "s3://lifebit-featured-datasets/pipelines/exomiser-data-bundle"
+    exomiser_profile = 'full'
     application_properties = 's3://lifebit-featured-datasets/pipelines/exomiser-nf/application.properties'
     auto_config_yml = 's3://lifebit-featured-datasets/pipelines/exomiser-nf/auto_config.yml'
 }

--- a/conf/tests/full/test_full_single_vcf.config
+++ b/conf/tests/full/test_full_single_vcf.config
@@ -2,7 +2,7 @@ params {
     families_file     = 's3://lifebit-featured-datasets/pipelines/exomiser-nf/single_vcf.tsv'
     hpo_terms_file  = 's3://lifebit-featured-datasets/pipelines/exomiser-nf/hpo_terms_file.txt'
     prioritisers    = 'hiPhivePrioritiser'
-    exomiser_profile = 'full'
+    exomiser_profile_files = 'full'
     application_properties = 's3://lifebit-featured-datasets/pipelines/exomiser-nf/application.properties'
     auto_config_yml = 's3://lifebit-featured-datasets/pipelines/exomiser-nf/auto_config.yml'
 }

--- a/conf/tests/full/test_full_single_vcf.config
+++ b/conf/tests/full/test_full_single_vcf.config
@@ -2,7 +2,7 @@ params {
     families_file     = 's3://lifebit-featured-datasets/pipelines/exomiser-nf/single_vcf.tsv'
     hpo_terms_file  = 's3://lifebit-featured-datasets/pipelines/exomiser-nf/hpo_terms_file.txt'
     prioritisers    = 'hiPhivePrioritiser'
-    exomiser_data   = "s3://lifebit-featured-datasets/pipelines/exomiser-data-bundle"
+    exomiser_profile = 'full'
     application_properties = 's3://lifebit-featured-datasets/pipelines/exomiser-nf/application.properties'
     auto_config_yml = 's3://lifebit-featured-datasets/pipelines/exomiser-nf/auto_config.yml'
 }

--- a/main.nf
+++ b/main.nf
@@ -129,7 +129,8 @@ ch_combined = ch_vcf_paths2.join(ch_to_join, by: 0).view()
 
 if (!params.data_bundle && params.exomiser_profile_files){
     exomiser_data=params.exomiser_data_profile[params.exomiser_profile_files].data_bundle
-    Channel.fromPath("${params.exomiser_data}")
+
+    Channel.fromPath("${exomiser_data}")
             .set{ch_exomiser_data }
 }else{
     Channel.fromPath("${params.data_bundle}")

--- a/main.nf
+++ b/main.nf
@@ -24,7 +24,7 @@ if(params.hpo_file) log.info "-${c_teal}filename_hpo:${c_reset}- ${params.filena
 if(params.ped_file) log.info "-${c_teal}filename_ped:${c_reset}- ${params.ped_file}"
 if(params.families_file) log.info "-${c_teal}families_file:${c_reset}- ${params.families_file}"
 log.info "-${c_teal}analysis_mode:${c_reset}- ${params.analysis_mode}"
-log.info "-${c_teal}exomiser_data:${c_reset}- ${params.exomiser_data}"
+log.info "-${c_teal}exomiser_data:${c_reset}- ${params.data_bundle}"
 log.info "-${c_teal}exomiser_phenotype_data:${c_reset}- ${params.exomiser_phenotype_data}"
 log.info "-${c_teal}phenix_data:${c_reset}- ${params.phenix_data}"
 log.info "-${c_teal}pathogenicity_sources:${c_reset}- ${params.pathogenicity_sources}"
@@ -127,15 +127,13 @@ ch_combined = ch_vcf_paths2.join(ch_to_join, by: 0).view()
   Run containarised Exomiser
 ---------------------------------------------------*/
 
-if(params.exomiser_data){
-          Channel.fromPath("${params.exomiser_data}")
-          .set{ch_exomiser_data }
-          }
-else{
-    exomiser_data=params.exomiser_profile[params.params.exomiser_profile_files].data_bundle
+if (!params.data_bundle && params.exomiser_profile_files){
+    exomiser_data=params.exomiser_profile[params.exomiser_profile_files].data_bundle
     Channel.fromPath("${params.exomiser_data}")
             .set{ch_exomiser_data }
-  
+}else{
+    Channel.fromPath("${params.data_bundle}")
+          .set{ch_exomiser_data }
 }
 
 

--- a/main.nf
+++ b/main.nf
@@ -127,7 +127,6 @@ ch_combined = ch_vcf_paths2.join(ch_to_join, by: 0).view()
   Run containarised Exomiser
 ---------------------------------------------------*/
 
-ld_score_annots = params.ld_score_weights_annotations[params.ld_score_weights_annotation_files].annotations
 if(params.exomiser_data){
           Channel.fromPath("${params.exomiser_data}")
           .set{ch_exomiser_data }

--- a/main.nf
+++ b/main.nf
@@ -136,7 +136,7 @@ if (!params.data_bundle && params.exomiser_profile_files){
           .set{ch_exomiser_data }
 }
 
-ch_exomiser_data.view()
+
 
 
 process exomiser {

--- a/main.nf
+++ b/main.nf
@@ -128,7 +128,7 @@ ch_combined = ch_vcf_paths2.join(ch_to_join, by: 0).view()
 ---------------------------------------------------*/
 
 if (!params.data_bundle && params.exomiser_profile_files){
-    exomiser_data=params.exomiser_profile[params.exomiser_profile_files].data_bundle
+    exomiser_data=params.exomiser_data_profile[params.exomiser_profile_files].data_bundle
     Channel.fromPath("${params.exomiser_data}")
             .set{ch_exomiser_data }
 }else{

--- a/main.nf
+++ b/main.nf
@@ -129,7 +129,6 @@ ch_combined = ch_vcf_paths2.join(ch_to_join, by: 0).view()
 
 if (!params.data_bundle && params.exomiser_profile_files){
     exomiser_data=params.exomiser_data_profile[params.exomiser_profile_files].data_bundle
-
     Channel.fromPath("${exomiser_data}")
             .set{ch_exomiser_data }
 }else{

--- a/main.nf
+++ b/main.nf
@@ -136,7 +136,7 @@ if (!params.data_bundle && params.exomiser_profile_files){
           .set{ch_exomiser_data }
 }
 
-
+ch_exomiser_data.view()
 
 
 process exomiser {

--- a/main.nf
+++ b/main.nf
@@ -127,7 +127,18 @@ ch_combined = ch_vcf_paths2.join(ch_to_join, by: 0).view()
   Run containarised Exomiser
 ---------------------------------------------------*/
 
-ch_exomiser_data = Channel.fromPath("${params.exomiser_data}")
+ld_score_annots = params.ld_score_weights_annotations[params.ld_score_weights_annotation_files].annotations
+if(params.exomiser_data){
+          Channel.fromPath("${params.exomiser_data}")
+          .set{ch_exomiser_data }
+          }
+else{
+    exomiser_data=params.exomiser_profile[params.params.exomiser_profile_files].exomiser_data
+    Channel.fromPath("${params.exomiser_data}")
+            .set{ch_exomiser_data }
+  
+}
+
 
 
 

--- a/main.nf
+++ b/main.nf
@@ -132,7 +132,7 @@ if(params.exomiser_data){
           .set{ch_exomiser_data }
           }
 else{
-    exomiser_data=params.exomiser_profile[params.params.exomiser_profile_files].exomiser_data
+    exomiser_data=params.exomiser_profile[params.params.exomiser_profile_files].data_bundle
     Channel.fromPath("${params.exomiser_data}")
             .set{ch_exomiser_data }
   

--- a/nextflow.config
+++ b/nextflow.config
@@ -23,10 +23,11 @@ params {
   filename_hpo = ''
   sample_name = null
   config = 'conf/executors/standard.config'
-  exomiser_data = 's3://lifebit-featured-datasets/pipelines/exomiser/very_fake/hg38'
-  exomiser_phenotype_data = 's3://lifebit-featured-datasets/pipelines/exomiser/very_fake/2102_phenotype'
-  cadd_snvs = 's3://lifebit-featured-datasets/pipelines/exomiser/very_fake/cadd_snvs'
-  phenix_data = 's3://lifebit-featured-datasets/pipelines/exomiser/very_fake/phenix'
+  exomiser_profile = 'full' // 'test' for small mock data, 'full' for full data (120GB)
+  exomiser_data = false
+  exomiser_phenotype_data = false
+  cadd_snvs = false
+  phenix_data = false
   application_properties = "${params.reference_data_bucket}/pipelines/exomiser-nf/application.properties"
   auto_config_yml = '${params.reference_data_bucket}/pipelines/exomiser-nf/auto_config_v2.yml'
   hpo_terms_file = false

--- a/nextflow.config
+++ b/nextflow.config
@@ -23,11 +23,11 @@ params {
   filename_hpo = ''
   sample_name = null
   config = 'conf/executors/standard.config'
-  exomiser_profile = 'full' // 'test' for small mock data, 'full' for full data (120GB)
-  exomiser_data = false
-  exomiser_phenotype_data = false
-  cadd_snvs = false
-  phenix_data = false
+  exomiser_profile_files = 'full' // 'test' for small mock data, 'full' for full data (120GB)
+  exomiser_data = null
+  exomiser_phenotype_data = null
+  cadd_snvs = null
+  phenix_data = null
   application_properties = "${params.reference_data_bucket}/pipelines/exomiser-nf/application.properties"
   auto_config_yml = '${params.reference_data_bucket}/pipelines/exomiser-nf/auto_config_v2.yml'
   hpo_terms_file = false
@@ -74,7 +74,7 @@ params {
 }
 
 includeConfig 'conf/containers/quay.config'
-includeConfig 'conf/data/data.config' // Loads in data
+//includeConfig 'conf/data/data.config' // Loads in data
 
 
 profiles {

--- a/nextflow.config
+++ b/nextflow.config
@@ -29,7 +29,7 @@ params {
   cadd_snvs = null
   phenix_data = null
   application_properties = "${params.reference_data_bucket}/pipelines/exomiser-nf/application.properties"
-  auto_config_yml = "${params.reference_data_bucket}/pipelines/exomiser-nf/auto_config_v2.yml"
+  auto_config_yml = "${params.reference_data_bucket}/pipelines/exomiser-nf/auto_config_V2.yml"
   hpo_terms_file = false
   modes_of_inheritance = 'AUTOSOMAL_DOMINANT,AUTOSOMAL_RECESSIVE,X_RECESSIVE,UNDEFINED'
   prioritisers = 'hiPhivePrioritiser,phivePrioritiser,phenixPrioritiser'

--- a/nextflow.config
+++ b/nextflow.config
@@ -24,7 +24,7 @@ params {
   sample_name = null
   config = 'conf/executors/standard.config'
   exomiser_profile_files = 'full' // 'test' for small mock data, 'full' for full data (120GB)
-  exomiser_data = null
+  data_bundle = null
   exomiser_phenotype_data = null
   cadd_snvs = null
   phenix_data = null

--- a/nextflow.config
+++ b/nextflow.config
@@ -29,7 +29,7 @@ params {
   cadd_snvs = null
   phenix_data = null
   application_properties = "${params.reference_data_bucket}/pipelines/exomiser-nf/application.properties"
-  auto_config_yml = '${params.reference_data_bucket}/pipelines/exomiser-nf/auto_config_v2.yml'
+  auto_config_yml = "${params.reference_data_bucket}/pipelines/exomiser-nf/auto_config_v2.yml"
   hpo_terms_file = false
   modes_of_inheritance = 'AUTOSOMAL_DOMINANT,AUTOSOMAL_RECESSIVE,X_RECESSIVE,UNDEFINED'
   prioritisers = 'hiPhivePrioritiser,phivePrioritiser,phenixPrioritiser'

--- a/nextflow.config
+++ b/nextflow.config
@@ -94,6 +94,7 @@ profiles {
 }
 
 includeConfig 'conf/resources.config'
+includeConfig 'conf/data/data.config'
 
 process {
   echo = params.echo


### PR DESCRIPTION
<!-- Note: None of the template header sections should be removed and each should be addressed -->

## Overview

This PR aims to standardize the pipeline to better conform to the template, according to the jira ticket and the discussion on SLACK on how to handle mock data.

> . There are workarounds for reference data when used in ci tests if reference data is too large for :github-actions: : https://github.com/lifebit-ai/finemapping/blob/dev/conf/data/data.config#L17 & https://github.com/lifebit-ai/finemapping/blob/dev/main.nf#L83 & https://github.com/lifebit-ai/finemapping/blob/dev/conf/tests/ci/test_ci_polyfun.config#L13


## Purpose
This PR aims to standardize the pipeline to better conform to the template. 

- parametrisation of the paths of the reference data for the pipeline  to better accommodate for different AWS regions using the `params.reference_data_bucket` parameter
- the collection of the reference/pipeline specific data in `conf/data/data.conf`


## Acceptance Criteria/Jira Ticket

<!-- Replace ticket code in square brackets [] and link in parentheses () -->
[DEL-16132](https://lifebit.atlassian.net/browse/DEL-16132)

## Changes


- Refactors the container names
- Refactors `nextflow.config` accordingly
- Refactors `conf/data/data.config` to accommodate for the new parametrisation of the path
- Refactors the documentation to reflect changes



## Internal CloudOS Tests
> Not necessary if run in Internal CloudOS CI
<!-- These should be updated every time a new test profile is added, renamed or removed -->
- [ ] [-profile test_full_family](https://cloudos.lifebit.ai/app/jobs/655b65acee3581581f19e0c7)
- [ ] [-profile test_full_multi_hpo](https://cloudos.lifebit.ai/app/jobs/655b6986ee3581581f1a164b)
- [ ] [-profile test_full_single_vcf](https://cloudos.lifebit.ai/app/jobs/655b68fbee3581581f1a0872)


## Client CloudOS Tests
<!-- These should be updated every time a new test profile is added, renamed or removed -->
- [ ] [-profile <replace_with_profile1>]()
- [ ] [-profile <replace_with_profile2>]()

## PR Checklist

#### Author to check:
<!-- These should be checked by author, review should not be requested until all are addressed -->
- [ ] The PR title is informative and begins with appropriate `[Fix:|Feat:|Docs:]` based on PR type
- [ ] This PR is raised to `dev` branch for DSL1 or `DSL2-dev` for DSL2 translations
- [ ] The description contains the acceptance criteria or link to the associated Jira ticket
- [ ] The description contains links to CloudOS tests covering all test cases in client environment

#### Reviewer to check:
<!-- These should be checked of by the reviewer only, check off even if NA for PR for completion -->
- [ ] A new test profile covering new functions for acceptance criteria is created if it does not already exist
- [ ] Nextflow configs have associated profiles named to match the config basename
- [ ] The [Jenkinsfile](https://github.com/lifebit-ai/<target_repo_name>/blob/dev/Jenkinsfile) has been updated with current Nextflow profiles
- [ ] The [internal_lifebit_cloudos_ci.yml](https://github.com/lifebit-ai/<target_repo_name>/blob/dev/.github/workflows/internal_lifebit_cloudos_ci.yml) has been updated to run all current Nextflow profiles
- [ ] Redundant tests have been removed
- [ ] The [README.md](https://github.com/lifebit-ai/<target_repo_name>/blob/dev/docs/README.md) has been updated with parameter changes and current `results/` and conforms to the README.md guidelines
- [ ] The code is logical, readable, reasonably optimal and meets the acceptance criteria
- [ ] The [containers](https://github.com/lifebit-ai/<target_repo_name>/blob/dev/containers) folder has been updated with the necessary containers to run this pipeline if needed


[DEL-16132]: https://lifebit.atlassian.net/browse/DEL-16132?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ